### PR TITLE
Make Test Timeout Configurable

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,1 @@
-{ "presets": [["env", {"targets": {"node": "6.1"}}]] }
+{ "presets": [["env", {"targets": {"node": "6.10"}}]] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -758,28 +758,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "fairmont-core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fairmont-core/-/fairmont-core-1.0.1.tgz",
-      "integrity": "sha1-OOBFbZ2KclIzpsNt+RiLJ7NnuCE=",
-      "dev": true
-    },
-    "fairmont-helpers": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fairmont-helpers/-/fairmont-helpers-3.0.0.tgz",
-      "integrity": "sha512-waCm93Y8u0/km+q1kST9PDVbaQdg/QPMWdDLguQohK88iQpn8FYQKh8BGTVIVTdx96nyGo8qbHybgiJBmiSO0g==",
-      "dev": true,
-      "requires": {
-        "fairmont-core": "1.0.1",
-        "fairmont-multimethods": "1.0.1"
-      }
-    },
-    "fairmont-multimethods": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fairmont-multimethods/-/fairmont-multimethods-1.0.1.tgz",
-      "integrity": "sha1-XUaIy+trrCYgYji2TBGgyKQgKYM=",
-      "dev": true
-    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amen",
-  "version": "1.0.6",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -694,12 +694,14 @@
       }
     },
     "coffeescript": {
-      "version": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.0.2.tgz",
-      "integrity": "sha1-BlcCpIS0YZS4x+sISB5tTcOLh8k=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.1.0.tgz",
+      "integrity": "sha512-RuEF4gFUV9QSFPREl8gx6w0vS6Ncnr0Nd71lOmxSHfKQFQI66meE54Y636TACbe55j2Lwi6R1O8lOa0dD550GA==",
       "dev": true
     },
     "colors": {
-      "version": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
     },
     "concat-map": {
@@ -754,6 +756,28 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "fairmont-core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fairmont-core/-/fairmont-core-1.0.1.tgz",
+      "integrity": "sha1-OOBFbZ2KclIzpsNt+RiLJ7NnuCE=",
+      "dev": true
+    },
+    "fairmont-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fairmont-helpers/-/fairmont-helpers-3.0.0.tgz",
+      "integrity": "sha512-waCm93Y8u0/km+q1kST9PDVbaQdg/QPMWdDLguQohK88iQpn8FYQKh8BGTVIVTdx96nyGo8qbHybgiJBmiSO0g==",
+      "dev": true,
+      "requires": {
+        "fairmont-core": "1.0.1",
+        "fairmont-multimethods": "1.0.1"
+      }
+    },
+    "fairmont-multimethods": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fairmont-multimethods/-/fairmont-multimethods-1.0.1.tgz",
+      "integrity": "sha1-XUaIy+trrCYgYji2TBGgyKQgKYM=",
       "dev": true
     },
     "globals": {
@@ -812,7 +836,8 @@
       "dev": true
     },
     "json": {
-      "version": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
       "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "coffeescript": "^2.1.0",
-    "fairmont-helpers": "^3.0.0",
     "json": "^9.0.3"
   },
   "engine": "node >= 6.0.0"

--- a/package.json
+++ b/package.json
@@ -34,13 +34,14 @@
   },
   "homepage": "https://github.com/pandastrike/amen",
   "dependencies": {
-    "colors": "^0.6.2",
-    "babel-polyfill": "^6.26.0"
+    "colors": "^0.6.2"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "coffeescript": "^2.0.0",
+    "coffeescript": "^2.1.0",
+    "fairmont-helpers": "^3.0.0",
     "json": "^9.0.3"
   },
   "engine": "node >= 6.0.0"

--- a/src/amen.coffee
+++ b/src/amen.coffee
@@ -1,19 +1,21 @@
 require "colors"
 
-timeout = (t, promise) ->
+race = (t, promise) ->
   timer = new Promise (_, reject) ->
     setTimeout (-> reject new Error "Async test timed out"), t
   Promise.race [ timer, promise ]
 
+timeout = (t, promise) -> if t then race t, promise else promise
+
 # TODO: use explicit result objects, instead of true | Error | undefined
-test = (description, definition) ->
+test = (description, definition, timeLimit=1000) ->
   if definition?
     if Array.isArray definition
       # TODO: include error/timeout/pending count in result object
       [description, (await result for result in definition) ]
     else if definition.call?
       try
-        await timeout 1000, definition()
+        await timeout timeLimit, definition()
         [ description, true ]
       catch error
         [ description, error ]

--- a/src/amen.coffee
+++ b/src/amen.coffee
@@ -1,21 +1,36 @@
 require "colors"
 
-race = (t, promise) ->
-  timer = new Promise (_, reject) ->
-    setTimeout (-> reject new Error "Async test timed out"), t
-  Promise.race [ timer, promise ]
+timer = (t) ->
+  new Promise (_, nope) ->
+    setTimeout (-> nope new Error "Test timed out"), t
 
-timeout = (t, promise) -> if t then race t, promise else promise
+race = (promises...) -> Promise.race [promises...]
+
+timeout = (t, promises...) -> race (timer t), promises...
+
+defaults =
+  wait: 500
 
 # TODO: use explicit result objects, instead of true | Error | undefined
-test = (description, definition, timeLimit=1000) ->
+test = (description, definition) ->
+  if description.constructor == Object
+    {description, wait} = description
+  else if description.constructor == String
+    {wait} = defaults
+  else
+    description = description.toString()
+
+
   if definition?
     if Array.isArray definition
       # TODO: include error/timeout/pending count in result object
       [description, (await result for result in definition) ]
     else if definition.call?
       try
-        await timeout timeLimit, definition()
+        if wait == false
+          await definition()
+        else
+          await timeout wait, definition()
         [ description, true ]
       catch error
         [ description, error ]

--- a/test/basic.coffee
+++ b/test/basic.coffee
@@ -1,0 +1,29 @@
+import {print, test} from "../src/amen"
+import assert from "assert"
+
+promise = (resolve, reject) -> new Promise resolve, reject
+
+good = -> promise (resolve) -> setTimeout resolve, 100
+bad = -> promise (_, reject) -> setTimeout (-> reject new Error "oops"), 100
+
+console.log "-".repeat 80
+console.log " IMPORTANT\n Basic tests should generate an error ('oops')
+              and have three failing tests\n and a pending test."
+console.log "-".repeat 80
+
+Test = ->
+  print await test "Start with the basics", [
+    test "A simple test", -> assert true
+    test "A nested test", [
+      test "I'm nested", -> assert true
+    ]
+    test "A failing test", -> assert false
+    test "A nested group of async tests", [
+      test "An async test", -> await good()
+      test "A failing async test", -> await bad()
+      test "An async test that never resolves", -> (promise ->)
+    ]
+    test "A pending test"
+  ]
+
+export default Test

--- a/test/custom-timeout.coffee
+++ b/test/custom-timeout.coffee
@@ -1,40 +1,34 @@
 import {print, test} from "../src/amen"
 import assert from "assert"
-import {sleep} from "fairmont-helpers"
 
-alwaysTrue = -> assert true
+timer = (wait, action) -> setTimeout(action, wait)
+
+sleep = (interval) ->
+  new Promise (resolve, reject) ->
+    timer interval, -> resolve()
+
 sleepyTrue = ->
-  await sleep 2000
+  await sleep 150
   assert true
 
 console.log "-".repeat 80
 console.log """
  IMPORTANT
- Custom Timeout tests should generate three timeout errors.
+ Custom Timeout tests should generate one pass and one timeout error.
 """
 console.log "-".repeat 80
 
 Test = ->
   print await test "Setting custom timeouts", [
-    test "A passing test with default timeout", alwaysTrue
-    test "A passing test with 500ms timeout", alwaysTrue, 500
+    test
+      description: "A passing test with 200ms timeout"
+      wait: 200,
+      sleepyTrue
 
-    test "A failing test with default timeout", sleepyTrue
-    test "A failing test with 500ms timeout", sleepyTrue, 500
-    test "A passing test with 2500ms timeout", sleepyTrue, 2500
-
-    test "A set of passing, nested tests that finish in time", [
-      test "nest 1", alwaysTrue
-      test "nest 2", alwaysTrue
-      test "nest 3", alwaysTrue
-    ], 1000
-
-    test "A set of nested tests that don't finish in time", [
-      test "nest 1", alwaysTrue
-      test "nest 2", alwaysTrue
-      test "nest 3", sleepyTrue
-    ], 1000
-
+    test
+      description: "A failing test with 50ms timeout"
+      wait: 50,
+      sleepyTrue
   ]
 
 export default Test

--- a/test/custom-timeout.coffee
+++ b/test/custom-timeout.coffee
@@ -1,0 +1,40 @@
+import {print, test} from "../src/amen"
+import assert from "assert"
+import {sleep} from "fairmont-helpers"
+
+alwaysTrue = -> assert true
+sleepyTrue = ->
+  await sleep 2000
+  assert true
+
+console.log "-".repeat 80
+console.log """
+ IMPORTANT
+ Custom Timeout tests should generate three timeout errors.
+"""
+console.log "-".repeat 80
+
+Test = ->
+  print await test "Setting custom timeouts", [
+    test "A passing test with default timeout", alwaysTrue
+    test "A passing test with 500ms timeout", alwaysTrue, 500
+
+    test "A failing test with default timeout", sleepyTrue
+    test "A failing test with 500ms timeout", sleepyTrue, 500
+    test "A passing test with 2500ms timeout", sleepyTrue, 2500
+
+    test "A set of passing, nested tests that finish in time", [
+      test "nest 1", alwaysTrue
+      test "nest 2", alwaysTrue
+      test "nest 3", alwaysTrue
+    ], 1000
+
+    test "A set of nested tests that don't finish in time", [
+      test "nest 1", alwaysTrue
+      test "nest 2", alwaysTrue
+      test "nest 3", sleepyTrue
+    ], 1000
+
+  ]
+
+export default Test

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1,28 +1,11 @@
+import "babel-polyfill"
 import {print, test} from "../src/amen"
 
-assert = require "assert"
-
-promise = (resolve, reject) -> new Promise resolve, reject
-
-good = -> promise (resolve) -> setTimeout resolve, 100
-bad = -> promise (_, reject) -> setTimeout (-> reject new Error "oops"), 100
-
-console.log "-".repeat 80
-console.log " IMPORTANT\n This test should generate an error ('oops')
-              and have three failing tests\n and a pending test."
-console.log "-".repeat 80
+import basic from "./basic"
+import customTimeout from "./custom-timeout"
 
 do ->
   print await test "Using Amen to test itself", [
-    test "A simple test", -> assert true
-    test "A nested test", [
-      test "I'm nested", -> assert true
-    ]
-    test "A failing test", -> assert false
-    test "A nested group of async tests", [
-      test "An async test", -> await good()
-      test "A failing async test", -> await bad()
-      test "An async test that never resolves", -> (promise ->)
-    ]
-    test "A pending test"
+    test "Basic Tests", basic, false
+    test "Custom Timeout", customTimeout, false
   ]

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -6,6 +6,13 @@ import customTimeout from "./custom-timeout"
 
 do ->
   print await test "Using Amen to test itself", [
-    test "Basic Tests", basic, false
-    test "Custom Timeout", customTimeout, false
+    test
+      description: "Basic Tests"
+      wait: false,
+      basic
+
+    test
+      description: "Custom Timeout"
+      wait: false,
+      customTimeout
   ]


### PR DESCRIPTION
This makes timeouts on Amen tests configurable and optional.  Default…behavior remains at 1000ms.

Test with:
```
npm install
npm test
```