### PR TITLE
Bug Fix: Prevent Reassignment of `test` Function During `print`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amen",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amen",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A simple test library for use with async functions",
   "keywords": [
     "test",

--- a/src/amen.coffee
+++ b/src/amen.coffee
@@ -44,8 +44,8 @@ test = (description, definition) ->
 print = ([description, result], indent="") ->
   if Array.isArray result
     console.log indent, description.blue
-    for test in result
-      print test, (indent + "  ")
+    for r in result
+      print r, (indent + "  ")
   else
     console.log indent,
       if result?

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -3,6 +3,7 @@ import {print, test} from "../src/amen"
 
 import basic from "./basic"
 import customTimeout from "./custom-timeout"
+import multiple from "./multiple-prints"
 
 do ->
   print await test "Using Amen to test itself", [
@@ -15,4 +16,9 @@ do ->
       description: "Custom Timeout"
       wait: false,
       customTimeout
+
+    test
+      description: "Multiple Prints"
+      wait: false,
+      multiple
   ]

--- a/test/multiple-prints.coffee
+++ b/test/multiple-prints.coffee
@@ -1,0 +1,19 @@
+import {print, test} from "../src/amen"
+import assert from "assert"
+
+Test = ->
+  print await test
+    description: "Allow Multiple Prints"
+    wait: false
+    ->
+      print await test "First Nested Print", [
+        test "test 1", -> assert true
+        test "test 2", -> assert true
+      ]
+
+      print await test "Second Nested Print", [
+        test "test 3", -> assert true
+        test "test 4", -> assert true
+      ]
+
+export default Test


### PR DESCRIPTION
Prevented reassignment of "test" function during printing process.  This prevented the use of multiple print expressions inside a test closure.  I added tests to support this use-case.